### PR TITLE
feat: 优化安装脚本，通过ghcr提供镜像下载

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,0 +1,14 @@
+
+name: docker-compose-actions-workflow
+on: push
+jobs:
+  check-docker-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: start juno assembly and juno service
+        run: docker-compose up --build -d
+      - name: sleep 10s
+        run: sleep 10
+      - name: docker ps
+        run: docker

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -11,4 +11,4 @@ jobs:
       - name: sleep 10s
         run: sleep 10
       - name: docker ps
-        run: docker
+        run: docker ps

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,6 +39,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image: ${{ env.IMAGE_NAME }}
           dockerfile: ./docker/juno-admin/Dockerfile
-          tags: v1, latest
+          tags: latest
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,44 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: juno-admin
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: image_name
+        run: echo ${{ env.IMAGE_NAME }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: mr-smithers-excellent/docker-build-push@v5.6
+        with:
+          registry: ${{ env.REGISTRY }}
+          image: ${{ env.IMAGE_NAME }}
+          dockerfile: ./docker/juno-admin/Dockerfile
+          tags: v1, latest
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}

--- a/config/juno/single-region-admin.toml
+++ b/config/juno/single-region-admin.toml
@@ -1,3 +1,4 @@
+#################################### APP Config #########################
 [app]
   secretKey = "ASDFASDFASDF" # hashStatecode
   mode = "single" # single without proxy, multiple with proxy
@@ -5,7 +6,6 @@
 [configure]
   dir = "/tmp/www/server"
   prefix = "juno-agent"
-
   [configure.agent]
     port = 50010
 
@@ -23,6 +23,7 @@
     async = false
     name = "biz.json" # 日志名称
     dir = "./logs"
+
 [session]
   maxAge = 172800
   secret = "ldfgoqnf935nvav34"
@@ -49,6 +50,14 @@
     host = "0.0.0.0"
     # The http port to use
     port = 50004
+
+#################################### Jupiter Config #########################
+[jupiter]
+    [jupiter.cron]
+        [jupiter.cron.parse]
+        withSeconds = false
+        concurrentDelay = 10
+        immediatelyRun = false
 
 #################################### Database ##############################
 [database]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,9 +54,9 @@ services:
       - prometheus
       
   juno-admin:
-    # image: 
-    build: 
-      context: ./docker/juno-admin/
+    image: ghcr.io/denisyin66/juno-admin:v1
+#    build: 
+#      context: ./docker/juno-admin/
     restart: always
     ports:
       - 50002:50002

--- a/docker/juno-admin/Dockerfile
+++ b/docker/juno-admin/Dockerfile
@@ -1,17 +1,18 @@
 FROM centos:7.2.1511
 
-ENV JUNO_VERSION=0.2.0
+ENV JUNO_VERSION=0.4.12
 
 RUN yum -y install wget openssh-clients git vim net-tools
 
 WORKDIR /root/juno/
 
-RUN wget -P /root/juno http://jupiter.douyu.com/download/${JUNO_VERSION}/juno_data_${JUNO_VERSION}.tar.gz && \
-    cd /root/juno && tar xvf juno_data_${JUNO_VERSION}.tar.gz
+RUN wget -P /root/juno https://github.com/douyu/juno/releases/download/v${JUNO_VERSION}/juno_${JUNO_VERSION}_linux_amd64.tar.gz && \
+    cd /root/juno && tar xvf juno_${JUNO_VERSION}_linux_amd64.tar.gz && \
+    mv /root/juno/juno-admin /usr/local/bin/
 
-RUN wget -P /root/juno/ http://jupiter.douyu.com/download/${JUNO_VERSION}/juno-admin_${JUNO_VERSION}_linux_amd64.tar.gz && \
-    cd /root/juno/ && tar xvf juno-admin_${JUNO_VERSION}_linux_amd64.tar.gz && \
-    mv /root/juno/juno-admin_${JUNO_VERSION}_linux_amd64/* /usr/local/bin/
+RUN wget -P /root/juno https://github.com/douyu/juno/archive/refs/tags/v${JUNO_VERSION}.tar.gz && \
+    cd /root/juno && tar xvf v${JUNO_VERSION}.tar.gz && \
+    mv /root/juno/juno-${JUNO_VERSION}/data /root/juno/
 
 RUN /usr/local/bin/juno-admin --version
 
@@ -23,6 +24,6 @@ RUN echo -e "#!/bin/bash\n/usr/local/bin/juno-admin --config=/root/juno/config/i
 RUN echo -e "#!/bin/bash\n/usr/local/bin/juno-admin --config=/root/juno/config/install.toml --mock=true" > /usr/local/bin/docker_juno_mock.sh && \
     chmod +x /usr/local/bin/docker_juno_mock.sh
 
-CMD ["/usr/local/bin/juno-admin", "--config=./config/single-region-admin.toml"]
+CMD ["/usr/local/bin/juno-admin", "--config=./config/single-region-admin.toml", "-host=0.0.0.0"]
 # CMD ["/sbin/init"]
 

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-JUNO_VER="0.4.0"
+JUNO_VER="0.4.12"
 DOWNLOAD_PATH="/home/opt"
 
 opt_env=no
@@ -51,11 +51,11 @@ fi
 
 # import shell script
 
-. init.sh
-. install_dir.sh
-. install_juno.sh
-. install_juno_admin.sh
-. install_juno_agent.sh
+. ./init.sh
+. ./install_dir.sh
+. ./install_juno.sh
+. ./install_juno_admin.sh
+. ./install_juno_agent.sh
 
 if [ "$opt_env" == "y" ];then
   Install_Env_Tools

--- a/shell/install_etcd.sh
+++ b/shell/install_etcd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget -P /home/opt http://jupiter.douyu.com/download/etcd-v3.4.9-linux-amd64.tar.gz
+wget -P /home/opt https://github.com/etcd-io/etcd/releases/download/v3.4.9/etcd-v3.4.9-linux-amd64.tar.gz
 cd /home/opt && tar -xzvf etcd-v3.4.9-linux-amd64.tar.gz
 mv etcd-v3.4.9-linux-amd64/* /home/www/system/etcd/
 chown -R www:www /home/www/system/etcd/

--- a/shell/install_go.sh
+++ b/shell/install_go.sh
@@ -2,10 +2,10 @@
 
 DOWNLOAD_PATH=/home/opt
 APP_PATH=/home/www/system/go
-APP_NAME=go1.14.4.linux-amd64
+APP_NAME=go1.17.3.linux-amd64
 
 mkdir -p ${APP_PATH}
-wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${APP_NAME}.tar.gz
+wget -P ${DOWNLOAD_PATH} https://studygolang.com/dl/golang/${APP_NAME}.tar.gz
 cd ${DOWNLOAD_PATH} && tar -xzvf ${APP_NAME}.tar.gz
 mv go/* ${APP_PATH}
 

--- a/shell/install_grafana.sh
+++ b/shell/install_grafana.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget -P /home/opt http://jupiter.douyu.com/download/grafana-7.0.5.linux-amd64.tar.gz
+wget -P /home/opt https://dl.grafana.com/oss/release/grafana-7.0.5.linux-amd64.tar.gz
 mkdir -p /home/www/server/grafana
 cd /home/opt && tar -xzvf grafana-7.0.5.linux-amd64.tar.gz
 mv ./grafana-7.0.5/* /home/www/server/grafana/

--- a/shell/install_juno.sh
+++ b/shell/install_juno.sh
@@ -2,8 +2,12 @@
 
 Install_Juno_Data()
 {
-    wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${JUNO_VER}/juno_data_${JUNO_VER}.tar.gz
-    tar -xzvf ${DOWNLOAD_PATH}/juno_data_${JUNO_VER}.tar.gz -C /home/www/server/juno/
+    wget -P ${DOWNLOAD_PATH} https://github.com/douyu/juno/archive/refs/tags/v${JUNO_VER}.tar.gz
+    tar -zxvf ${DOWNLOAD_PATH}/v${JUNO_VER}.tar.gz -C ${DOWNLOAD_PATH}
+    mv ${DOWNLOAD_PATH}/juno-${JUNO_VER}/data /home/www/server/juno/
+    cp -r ./../config/juno/ /home/www/server/juno/config/
+    cp -r ./../config/grafana/ /home/www/server/juno/config/
+    
     sed -i 's/root:root/root:/' /home/www/server/juno/config/single-region-admin.toml
     sed -i 's/root:root/root:/' /home/www/server/juno/config/install.toml
     sed -i 's/root:root/root:/' /home/www/server/juno/config/multiple-region-admin.toml

--- a/shell/install_juno_admin.sh
+++ b/shell/install_juno_admin.sh
@@ -2,9 +2,10 @@
 
 Install_Juno_Admin()
 {
-    wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${JUNO_VER}/juno-admin_${JUNO_VER}_linux_amd64.tar.gz
-    tar -xzvf ${DOWNLOAD_PATH}/juno-admin_${JUNO_VER}_linux_amd64.tar.gz -C /home/www/server/juno/
-    mv /home/www/server/juno/juno-admin_${JUNO_VER}_linux_amd64/* /home/www/server/juno/bin/
+    wget -P ${DOWNLOAD_PATH} https://github.com/douyu/juno/releases/download/v${JUNO_VER}/juno_${JUNO_VER}_linux_amd64.tar.gz
+    tar -xzvf ${DOWNLOAD_PATH}/juno_${JUNO_VER}_linux_amd64.tar.gz -C /home/www/server/juno/
+    mv /home/www/server/juno/juno-admin /home/www/server/juno/bin/
+    mv /home/www/server/juno/juno-proxy /home/www/server/juno/bin/
     cat > /etc/systemd/system/juno-admin.service <<END
 [Unit]
 Description=Juno Admin Server

--- a/shell/install_juno_agent.sh
+++ b/shell/install_juno_agent.sh
@@ -4,15 +4,18 @@ Install_Juno_Agent()
 {
     APP_PATH=/home/www/server/juno-agent
     APP_PATH_BIN=${APP_PATH}/bin
-    APP_NAME=juno-agent_${JUNO_VER}_linux_amd64
+    APP_NAME=juno-agent_${JUNO_AGENT_VER}_linux_amd64
+    JUNO_AGENT_VER=0.2.2
 
     mkdir -p ${APP_PATH_BIN}
-    wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${JUNO_VER}/${APP_NAME}.tar.gz
+    wget - P ${DOWNLOAD_PATH} https://github.com/douyu/juno-agent/releases/download/v${JUNO_AGENT_VER}/juno-agent_${JUNO_AGENT_VER}_linux_amd64.tar.gz
     tar xvf ${DOWNLOAD_PATH}/${APP_NAME}.tar.gz -C ${APP_PATH}
     mv /home/www/server/juno-agent/${APP_NAME}/* ${APP_PATH_BIN}
 
-    wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${JUNO_VER}/juno-agent_data_${JUNO_VER}.tar.gz
-    tar xvf ${DOWNLOAD_PATH}/juno-agent_data_${JUNO_VER}.tar.gz -C ${APP_PATH}
+
+    wget -P ${DOWNLOAD_PATH} https://github.com/douyu/juno-agent/archive/refs/tags/v${JUNO_AGENT_VER}.tar.gz
+    tar xvf v${JUNO_AGENT_VER}.tar.gz -C ${APP_PATH}
+    mv ${APP_PATH}/juno-agent-${JUNO_AGENT_VER}/config/ ${APP_PATH}/config/
 
     chown -R www:www ${APP_PATH}
 
@@ -47,3 +50,4 @@ END
     systemctl enable juno-agent.service
     systemctl start juno-agent.service
 }
+

--- a/shell/install_pprof.sh
+++ b/shell/install_pprof.sh
@@ -7,8 +7,8 @@ APP_NAME=pprof
 mkdir -p ${APP_PATH}
 mkdir -p ${APP_PATH}/graphviz
 chown -R www:www ${APP_PATH}
-wget -P ${DOWNLOAD_PATH} http://jupiter.douyu.com/download/${APP_NAME}.tar.gz
-cd ${DOWNLOAD_PATH} && tar -xzvf ${APP_NAME}.tar.gz
+
+wget -P ${DOWNLOAD_PATH}/${APP_NAME} --no-check-certificate https://www2.graphviz.org/Packages/stable/portable_source/graphviz-2.44.0.tar.gz
 cd ${DOWNLOAD_PATH}/${APP_NAME} && tar zxvf graphviz-2.44.0.tar.gz
 cd ${DOWNLOAD_PATH}/${APP_NAME}/graphviz-2.44.0 && ./configure --prefix=${APP_PATH}/graphviz
 cd ${DOWNLOAD_PATH}/${APP_NAME}/graphviz-2.44.0 && make && make install

--- a/shell/install_prometheus.sh
+++ b/shell/install_prometheus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget -P /home/opt http://jupiter.douyu.com/download/prometheus-2.19.2.linux-amd64.tar.gz
+wget -P /home/opt https://github.com/prometheus/prometheus/releases/download/v2.19.2/prometheus-2.19.2.linux-amd64.tar.gz
 cd /home/opt && tar -xzvf prometheus-2.19.2.linux-amd64.tar.gz
 mv ./prometheus-2.19.2.linux-amd64/* /home/www/system/prometheus/
 


### PR DESCRIPTION
fix: docker-compose 安装方式报错,文件下载不到 
feature: 增加github-ci进行检测，确保juno-install脚本一直可用
feature: 增加juno-admin docker镜像，用户可以基于docker-compose快速部署自己的juno项目。不必要等待过长时间